### PR TITLE
[H-01] - Fixes transferModuleOwnership to be scoped to module owner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ out/
 
 # Dotenv file
 .env
+
+.DS_Store

--- a/src/LilypadModuleDirectory.sol
+++ b/src/LilypadModuleDirectory.sol
@@ -255,7 +255,7 @@ contract LilypadModuleDirectory is ILilypadModuleDirectory, Initializable, Acces
         address newOwner,
         string memory moduleName,
         string memory moduleUrl
-    ) external override returns (bool) {
+    ) external override moduleOwnerOnly(moduleOwner, moduleName) returns (bool) {
         if (!_moduleExists[moduleOwner][moduleName]) {
             revert LilypadModuleDirectory__ModuleNotFound();
         }

--- a/test/LilypadModuleDirectory.t.sol
+++ b/test/LilypadModuleDirectory.t.sol
@@ -406,8 +406,17 @@ contract LilypadModuleDirectoryTest is Test {
         vm.startPrank(CONTROLLER);
         moduleDirectory.registerModuleForCreator(ALICE, "module1", "url1");
 
-        vm.startPrank(BOB);
+        vm.startPrank(ALICE);
         vm.expectRevert(LilypadModuleDirectory.LilypadModuleDirectory__TransferNotApproved.selector);
+        moduleDirectory.transferModuleOwnership(ALICE, BOB, "module1", "url1");
+    }
+
+    function test_RevertWhen_TransferringWhenNotModuleOwner() public {
+        vm.startPrank(CONTROLLER);
+        moduleDirectory.registerModuleForCreator(ALICE, "module1", "url1");
+
+        vm.startPrank(BOB);
+        vm.expectRevert(LilypadModuleDirectory.LilypadModuleDirectory__NotModuleOwner.selector);
         moduleDirectory.transferModuleOwnership(ALICE, BOB, "module1", "url1");
     }
 


### PR DESCRIPTION
## Summary

This pull request makes the following changes:

- [x] Makes transferModuleOwnership callable only by the module owner
- [x] Adds unit test to cover the above scenario

Explain the motivation for making these changes. Does this pull request implement a feature or fix a bug? Is it a docs change or a typo fix?

### Description
The current transferModuleOwnership function allows transferring the ownership of a
module to a new owner. However, the function does not verify the identity of the caller.

### Vulnerability Details
The transferModuleOwnership function transfers the ownership of a module to newOwner
and checks if the newOwner is already approved by the previous owner by comparing
with _transferApprovals[moduleOwner][moduleName].

If the current owner did not approve any wallets, the value of
_transferApprovals[moduleOwner][moduleName] is 0 by default.
It means malicious actors could transfer any module's ownership to zero address.

### Task/Issue reference

Closes: add_link_here

### Test plan

Please describe how reviewers can test the changes in this pull request. If the test plan is challenging to explain in text alone, a short video demonstration may be included.

### Details (optional)

Add any additional details that will help to review this pull request.

### Related issues or PRs (optional)

Add any related issues or PRs.